### PR TITLE
update overlapping condition

### DIFF
--- a/src/model/output/decoded/greedy.rs
+++ b/src/model/output/decoded/greedy.rs
@@ -60,7 +60,7 @@ impl GreedySearch {
     /// * and neither span is nested in into another, unless `flat_ner` is set to `false`
     fn overlapping(s1: &Span, s2: &Span, flat_ner: bool, multi_label: bool) -> bool {
         if s1.same_offsets(s2) { !multi_label }
-        else if flat_ner && (s1.is_nested_in(s2) || s2.is_nested_in(s1)) { false }
+        else if flat_ner && (s1.is_nested_in(s2) || s2.is_nested_in(s1)) { true }
         else { s1.overlaps(s2) }
     }
 }


### PR DESCRIPTION
Issue Summary
The logic in the GreedySearch::overlapping method appears to be inverted for the flat_ner case. Specifically, when flat_ner is true and one span is nested within another, the function currently returns false, meaning the spans are not considered overlapping. This contradicts the expected behavior for flat_ner = true, where nested entities should be treated as overlapping.

Problematic Code
```rust
fn overlapping(s1: &Span, s2: &Span, flat_ner: bool, multi_label: bool) -> bool {
    if s1.same_offsets(s2) { 
        !multi_label 
    } else if flat_ner && (s1.is_nested_in(s2) || s2.is_nested_in(s1)) { 
        false 
    } else { 
        s1.overlaps(s2) 
    }
}
```

The issue lies in the following conditional statement:

```rust
else if flat_ner && (s1.is_nested_in(s2) || s2.is_nested_in(s1)) { false }
```

This logic suggests that when flat_ner is true and one span is nested within another, the spans are not considered overlapping. As a result, nested spans are incorrectly allowed to coexist in the output.

Expected Behavior
With flat_ner = true, nested entities should be treated as overlapping and handled accordingly. This ensures that only the most relevant spans are retained, preventing incorrect entity groupings.

Proposed Fix
Modify the conditional logic to correctly enforce overlap detection for nested spans when flat_ner is enabled.