### PR TITLE
Return Err instead of panicking in the output decoder

### DIFF
--- a/src/model/output/decoded/greedy.rs
+++ b/src/model/output/decoded/greedy.rs
@@ -2,6 +2,7 @@
 
 use composable::Composable;
 use crate::util::result::Result;
+use crate::util::error::IndexError;
 use crate::text::span::Span;
 use super::SpanOutput;
 
@@ -27,9 +28,9 @@ impl GreedySearch {
     /// Perform greedy search
     /// 
     /// Note: spans are supposed to be sorted by start, and then end, offsets.
-    pub fn search(&self, spans: &[Span]) -> Vec<Span> {
+    pub fn search(&self, spans: &[Span]) -> Result<Vec<Span>> {
         if spans.is_empty() {
-            return Vec::new();
+            return Ok(Vec::new());
         }
 
         let mut result = Vec::with_capacity(spans.len());
@@ -37,8 +38,8 @@ impl GreedySearch {
         let mut next = 1usize;
 
         while next < spans.len() {
-            let prev_span = spans.get(prev).unwrap();
-            let next_span = spans.get(next).unwrap();
+            let prev_span = spans.get(prev).ok_or(IndexError::new("greedy search spans", prev))?;
+            let next_span = spans.get(next).ok_or(IndexError::new("greedy search spans", next))?;
             if self.accept(prev_span, next_span) {
                 result.push(prev_span.clone());
                 prev = next;
@@ -49,10 +50,10 @@ impl GreedySearch {
             next += 1;
         }
 
-        let prev_span = spans.get(prev).unwrap();
+        let prev_span = spans.get(prev).ok_or(IndexError::new("greedy search spans", prev))?;
         result.push(prev_span.clone());
 
-        result
+        Ok(result)
     }
 
     /// Returns `true` iif the span is valid wrt. the provided flags.
@@ -82,7 +83,7 @@ impl Composable<SpanOutput, SpanOutput> for GreedySearch {
         let spans = input.spans
             .iter()
             .map(|s| self.search(s))
-            .collect();
+            .collect::<Result<Vec<Vec<Span>>>>()?;
         Ok(SpanOutput::new(input.texts, input.entities, spans))
     }
 }

--- a/src/model/output/decoded/span.rs
+++ b/src/model/output/decoded/span.rs
@@ -3,6 +3,7 @@
 use composable::Composable;
 use crate::util::math::sigmoid;
 use crate::util::result::Result;
+use crate::util::error::IndexError;
 use crate::text::span::Span;
 use crate::model::pipeline::context::EntityContext;
 use crate::model::output::tensors::TensorOutput;
@@ -49,7 +50,7 @@ impl TensorsToDecoded {
         for sequence_id in 0..batch_size {
             // get a slice for the current sequence (1st dimension)
             let sequence = array.slice(ndarray::s![sequence_id, .., .., ..]);
-            let num_tokens = input.context.tokens.get(sequence_id).unwrap().len();
+            let num_tokens = input.context.tokens.get(sequence_id).ok_or(IndexError::new("span decode: meta.tokens", sequence_id))?.len();
             //println!("{:?}", sequence.map(|x| crate::util::math::sigmoid(*x)));
             
             // prepare the list of spans for this sequence

--- a/src/model/output/decoded/token.rs
+++ b/src/model/output/decoded/token.rs
@@ -2,6 +2,7 @@
 
 use composable::Composable;
 use crate::util::result::Result;
+use crate::util::error::IndexError;
 use crate::util::math::sigmoid;
 use crate::text::span::Span;
 use crate::model::pipeline::context::EntityContext;
@@ -61,9 +62,9 @@ impl TensorsToDecoded {
             let scores_inside = scores.slice(ndarray::s![2, .., ..]);            
 
             // generate all possible spans and iterate over them
-            for span in self.generate_spans(&scores_start, &scores_end) {
+            for span in self.generate_spans(&scores_start, &scores_end)? {
                 // compute score
-                let score = self.compute_span_score(span, &scores_inside);
+                let score = self.compute_span_score(span, &scores_inside)?;
                 // reject span if score is below threshold
                 if score < self.threshold {
                     continue
@@ -71,7 +72,7 @@ impl TensorsToDecoded {
                 // create actual span
                 let (start_token, end_token, class) = span;
                 let span = input.context.create_span(sequence_id, start_token, end_token, class, score)?;
-                result.get_mut(sequence_id).unwrap().push(span);
+                result.get_mut(sequence_id).ok_or(IndexError::new("token decode result", sequence_id))?.push(span);
             }
         }
         Ok(result)
@@ -83,18 +84,22 @@ impl TensorsToDecoded {
     /// * `score(i) >= threshold`
     /// * `score(j) >= threshold`.
     /// * `c` == `class(i) == class(j)`
-    fn generate_spans(&self, scores_start: &ndarray::ArrayView2::<f32>, scores_end: &ndarray::ArrayView2::<f32>) -> Vec<(usize, usize, usize)> {
-        assert!(scores_start.dim() == scores_end.dim());
+    fn generate_spans(&self, scores_start: &ndarray::ArrayView2::<f32>, scores_end: &ndarray::ArrayView2::<f32>) -> Result<Vec<(usize, usize, usize)>> {
+        // Return Err on a malformed model output instead of asserting, so the
+        // caller gets a clean error rather than a panic.
+        if scores_start.dim() != scores_end.dim() {
+            return Err(IndexError::with("token decode: start/end score dimensions differ").into());
+        }
         let (num_tokens, num_classes) = scores_start.dim();
         let mut result = Vec::new();
         for class in 0..num_classes {
             for start in 0..num_tokens {            
-                let score_start = sigmoid(*scores_start.get((start, class)).unwrap());
+                let score_start = sigmoid(*scores_start.get((start, class)).ok_or(IndexError::with("token decode: start score index out of bounds"))?);
                 if score_start < self.threshold {
                     continue
                 }
                 for end in start..num_tokens {
-                    let score_end = sigmoid(*scores_end.get((end, class)).unwrap());
+                    let score_end = sigmoid(*scores_end.get((end, class)).ok_or(IndexError::with("token decode: end score index out of bounds"))?);
                     if score_end < self.threshold {
                         continue
                     }
@@ -102,25 +107,29 @@ impl TensorsToDecoded {
                 }
             }
         }
-        result 
+        Ok(result)
     }
 
 
     /// Computes the score of a span, defined as the mean of the inside scores (see above).
     /// Spans with one or more inside scores below the threshold will return a zero score, 
     /// since they should be discarded.
-    fn compute_span_score(&self, span: (usize, usize, usize), scores_inside: &ndarray::ArrayView2<f32>) -> f32 {
+    fn compute_span_score(&self, span: (usize, usize, usize), scores_inside: &ndarray::ArrayView2<f32>) -> Result<f32> {
         let (start, end, class) = span;
-        assert!(end >= start);
+        // Return Err on a malformed model output instead of asserting, so the
+        // caller gets a clean error rather than a panic.
+        if end < start {
+            return Err(IndexError::with("token decode: span end precedes start").into());
+        }
         let mut sum = 0f32;
         for i in start..end+1 {
-            let score_inside = sigmoid(*scores_inside.get((i, class)).unwrap());
+            let score_inside = sigmoid(*scores_inside.get((i, class)).ok_or(IndexError::with("token decode: inside score index out of bounds"))?);
             if score_inside < self.threshold {
-                return 0.;
+                return Ok(0.);
             }
             sum += score_inside;
         }
-        sum / ((end - start + 1) as f32)
+        Ok(sum / ((end - start + 1) as f32))
     }
     
 
@@ -143,5 +152,83 @@ impl Composable<TensorOutput<'_>, SpanOutput> for TensorsToDecoded {
     fn apply(&self, input: TensorOutput) -> Result<SpanOutput> {        
         let decoded = self.decode(&input)?;
         Ok(SpanOutput::new(input.context.texts, input.context.entities, decoded))
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A start/end score tensor shape mismatch (a model output-shape invariant
+    /// break) must return Err from `generate_spans` instead of panicking on a
+    /// dimension assertion.
+    #[test]
+    fn generate_spans_rejects_mismatched_dims() {
+        let decoder = TensorsToDecoded::new(0.5);
+        let scores_start = ndarray::Array2::<f32>::zeros((2, 3));
+        let scores_end = ndarray::Array2::<f32>::zeros((3, 2));
+        let result = decoder.generate_spans(&scores_start.view(), &scores_end.view());
+        assert!(result.is_err(), "mismatched start/end dims must return Err, not panic");
+    }
+
+    /// A span whose end precedes its start must return Err from
+    /// `compute_span_score` instead of panicking.
+    #[test]
+    fn compute_span_score_rejects_end_before_start() {
+        let decoder = TensorsToDecoded::new(0.5);
+        let scores_inside = ndarray::Array2::<f32>::zeros((4, 2));
+        let result = decoder.compute_span_score((3, 1, 0), &scores_inside.view());
+        assert!(result.is_err(), "span end before start must return Err, not panic");
+    }
+
+    /// Positive path: well formed start/end/inside score tensors whose sigmoids
+    /// sit above the threshold decode end to end - `generate_spans` returns
+    /// exactly the expected `(start, end, class)` tuples, and
+    /// `compute_span_score` returns `Ok(mean-of-inside)`, proving behavior is
+    /// preserved on valid input.
+    ///
+    /// Construction (threshold 0.4, sigmoid(x) = 1 / (1 + e^-x)):
+    ///   * start logits `[10.0, -10.0]` -> sigmoids ~0.99995 / ~0.00005, so only
+    ///     token 0 clears the threshold as a span start;
+    ///   * end logits `[-10.0, 10.0]` -> only token 1 clears it as a span end;
+    ///     the sole admissible span is therefore `(start = 0, end = 1, class = 0)`;
+    ///   * inside logits `[ln 3, 0.0]` -> sigmoids exactly 0.75 and 0.5 (both above
+    ///     0.4, so the below-threshold zero short-circuit does not fire), whose
+    ///     mean is `(0.75 + 0.5) / 2 = 0.625`.
+    #[test]
+    fn generate_spans_and_score_positive_path() {
+        let decoder = TensorsToDecoded::new(0.4);
+
+        // (num_tokens, num_classes) = (2, 1), row-major: element (token, class).
+        // Only start-token 0 and end-token 1 clear the threshold.
+        let scores_start =
+            ndarray::Array2::<f32>::from_shape_vec((2, 1), vec![10.0, -10.0]).unwrap();
+        let scores_end =
+            ndarray::Array2::<f32>::from_shape_vec((2, 1), vec![-10.0, 10.0]).unwrap();
+
+        let spans = decoder
+            .generate_spans(&scores_start.view(), &scores_end.view())
+            .expect("valid start/end tensors must decode without error");
+
+        assert_eq!(
+            spans,
+            vec![(0, 1, 0)],
+            "the sole threshold-clearing (start, end, class) span must be (0, 1, 0)"
+        );
+
+        // sigmoid(ln 3) = 3 / (1 + 3) = 0.75; sigmoid(0) = 0.5; mean = 0.625.
+        let scores_inside =
+            ndarray::Array2::<f32>::from_shape_vec((2, 1), vec![3.0_f32.ln(), 0.0]).unwrap();
+
+        let score = decoder
+            .compute_span_score(spans[0], &scores_inside.view())
+            .expect("an all-above-threshold span must score without error");
+
+        assert!(
+            (score - 0.625).abs() < 1e-5,
+            "span score must be the mean of the inside sigmoids (0.75 + 0.5) / 2 = 0.625, got {}",
+            score
+        );
     }
 }

--- a/src/model/output/decoded/token_flat.rs
+++ b/src/model/output/decoded/token_flat.rs
@@ -3,6 +3,7 @@
 use std::iter;
 use composable::Composable;
 use crate::util::result::Result;
+use crate::util::error::IndexError;
 use crate::model::output::tensors::TensorOutput;
 use crate::{model::pipeline::context::EntityContext, text::span::Span};
 use crate::util::math::sigmoid;
@@ -43,7 +44,7 @@ impl FlatTokenDecoder {
         // iterate over the whole vector
         for start_idx in 0..position_padding {
             // check the start token score is above threshold, otherwise continue
-            if sigmoid(Self::get(model_output, start_idx)) < self.threshold {
+            if sigmoid(Self::get(model_output, start_idx)?) < self.threshold {
                 continue
             }
 
@@ -62,9 +63,9 @@ impl FlatTokenDecoder {
 
             while (((end_idx / sequence_padding) % batch_size) == sequence_id) && (end_idx < 2 * position_padding) {
                 // check the end token score is above threshold, otherwise continue
-                if sigmoid(Self::get(model_output, end_idx)) >= self.threshold {
+                if sigmoid(Self::get(model_output, end_idx)?) >= self.threshold {
                     // we won't consider a span at all if it contains a score below the threshold
-                    let score = sigmoid(Self::get(model_output, end_idx + position_padding));
+                    let score = sigmoid(Self::get(model_output, end_idx + position_padding)?);
                     if score < self.threshold {
                         break
                     }
@@ -77,7 +78,7 @@ impl FlatTokenDecoder {
 
                         // actually create the span
                         let span = input.create_span(sequence_id, start_token, end_token, class, probability)?;
-                        spans.get_mut(sequence_id).unwrap().push(span);
+                        spans.get_mut(sequence_id).ok_or(IndexError::new("flat token decode spans", sequence_id))?.push(span);
                     }
                 }
 
@@ -90,8 +91,8 @@ impl FlatTokenDecoder {
         Ok(spans)
     }
 
-    #[inline] fn get(model_output: &[f32], index: usize) -> f32 {
-        *model_output.get(index).unwrap()
+    #[inline] fn get(model_output: &[f32], index: usize) -> Result<f32> {
+        Ok(*model_output.get(index).ok_or(IndexError::new("flat token decode model output", index))?)
     }
 }
 
@@ -114,5 +115,21 @@ impl Composable<TensorOutput<'_>, SpanOutput> for TensorsToDecoded {
         let (_shape, logits) = logits.try_extract_raw_tensor::<f32>()?;
         let spans = self.decoder.decode(logits, &input.context)?;        
         Ok(SpanOutput::new(input.context.texts, input.context.entities, spans))      
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// An out-of-bounds index into the flat model-output slice must return Err
+    /// from `get` instead of panicking. A valid index still returns Ok, so
+    /// behavior is preserved on well formed input.
+    #[test]
+    fn get_out_of_bounds_returns_err() {
+        let model_output = [0.1f32, 0.2, 0.3];
+        assert!(FlatTokenDecoder::get(&model_output, 99).is_err());
+        assert!(FlatTokenDecoder::get(&model_output, 1).is_ok());
     }
 }

--- a/src/model/output/relation.rs
+++ b/src/model/output/relation.rs
@@ -73,12 +73,10 @@ impl Relation {
     
     fn decode(rel_class: &str) -> Result<(String, String)> {
         let split: Vec<&str> = rel_class.split(" <> ").collect();
-        if split.len() != 2 {
-            RelationFormatError::invalid_relation_label(rel_class).err()
+        match split.as_slice() {
+            [subject, object] => Ok((subject.to_string(), object.to_string())),
+            _ => RelationFormatError::invalid_relation_label(rel_class).err(),
         }
-        else {
-            Ok((split.get(0).unwrap().to_string(), split.get(1).unwrap().to_string()))
-        }        
     }
 }
 
@@ -172,5 +170,37 @@ impl std::error::Error for RelationFormatError { }
 impl std::fmt::Display for RelationFormatError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&self.message)
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A relation label lacking the " <> " subject/object separator (a malformed
+    /// model output) must return Err from `Relation::decode` instead of panicking
+    /// on an unwrap of the split parts.
+    #[test]
+    fn decode_rejects_label_without_separator() {
+        assert!(Relation::decode("no-separator-here").is_err());
+    }
+
+    /// A label with more than one separator (three parts) is rejected too,
+    /// preserving the `len() != 2` semantics.
+    #[test]
+    fn decode_rejects_label_with_extra_separator() {
+        assert!(Relation::decode("subject <> object <> extra").is_err());
+    }
+
+    /// A well-formed "<subject> <> <object>" label still decodes to its two
+    /// parts (behavior preserved on valid input). `.ok()` keeps the assertion
+    /// free of unwrap/expect/panic.
+    #[test]
+    fn decode_splits_valid_label() {
+        assert_eq!(
+            Relation::decode("works_at <> ORG").ok(),
+            Some(("works_at".to_string(), "ORG".to_string()))
+        );
     }
 }


### PR DESCRIPTION
First, thanks for gline-rs. We run it in production for NER and relation extraction, and the API has held up well. We call the inference pipeline from a Rust NIF on the Erlang VM, so a panic in a dependency is something we actively guard against (we wrap calls in `catch_unwind`). While auditing that boundary I noticed the output decoder still has a few `unwrap()` / `assert!()` calls that assume a particular shape in the model output. On well formed model output they never fire, but a shape or token alignment mismatch turns into a panic rather than the `Result::Err` the rest of the pipeline returns.

This converts those sites to `Result::Err` via `util::error::IndexError`, matching the existing `EntityContext::create_span` convention. Behavior on well formed output is unchanged, only the failure mode changes.

Signatures lifted to `Result`:
- `token::TensorsToDecoded::generate_spans` and `compute_span_score`
- `token_flat::FlatTokenDecoder::get`
- `greedy::GreedySearch::search` (its sole caller, the `Composable::apply` impl, collects into `Result`)

Adds `#[cfg(test)]` regression tests for a token shape mismatch, a span whose end precedes its start, a flat index out of range, and a malformed relation label.

The `greedy.rs` unwraps are bounded by the loop and look safe.
