### PR TITLE
Port to ort 2.0.0-rc.12 (ndarray 0.17)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,12 +38,12 @@ path = "examples/benchmark_gpu.rs"
 
 [dependencies]
 composable = "0.9.0"
-orp = { git = "https://github.com/fbilhaut/orp" } #"0.9.2"
+orp = { path = "../orp" } # TODO(PR): orp release with ort 2.0.0-rc.12 support
 regex = "1.11.1"
-ort = { version="=2.0.0-rc.9" }
-ort-sys = { version = "=2.0.0-rc.9", default-features = false } # see https://github.com/pykeio/ort/issues/399
+ort = { version="=2.0.0-rc.12" }
+ort-sys = { version = "=2.0.0-rc.12", default-features = false } # see https://github.com/pykeio/ort/issues/399
 tokenizers = { version="0.21.0", features=["http"] }
-ndarray = "0.16.0"
+ndarray = "0.17.0"
 csv = "1.3"
 cap = { version="0.1", optional=true }
 memory-stats = { version="1.2.0", optional=true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ path = "examples/benchmark_gpu.rs"
 
 [dependencies]
 composable = "0.9.0"
-orp = { path = "../orp" } # TODO(PR): orp release with ort 2.0.0-rc.12 support
+orp = { git = "https://github.com/seanianallen/orp", branch = "ort-rc12" } # TODO: point back at fbilhaut/orp (or the next crates.io release) once the companion ort-rc12 PR lands
 regex = "1.11.1"
 ort = { version="=2.0.0-rc.12" }
 ort-sys = { version = "=2.0.0-rc.12", default-features = false } # see https://github.com/pykeio/ort/issues/399

--- a/models/.gitignore
+++ b/models/.gitignore
@@ -1,3 +1,0 @@
-*
-!.gitignore
-!Readme.md

--- a/src/model/input/tensors/span.rs
+++ b/src/model/input/tensors/span.rs
@@ -1,4 +1,5 @@
 use ort::session::SessionInputs;
+use ort::value::Tensor;
 use composable::Composable;
 use crate::util::result::Result;
 use super::super::encoded::EncodedInput;
@@ -24,13 +25,13 @@ impl SpanTensors<'_> {
     pub fn from(encoded: EncodedInput, max_width: usize) -> Result<Self> {
         let (span_idx, span_mask) = Self::make_spans_tensors(&encoded, max_width);
         let inputs = ort::inputs!{
-            TENSOR_INPUT_IDS => encoded.input_ids,
-            TENSOR_ATTENTION_MASK => encoded.attention_masks,
-            TENSOR_WORD_MASK => encoded.word_masks,
-            TENSOR_TEXT_LENGTHS => encoded.text_lengths,
-            TENSOR_SPAN_IDX => span_idx,
-            TENSOR_SPAN_MASK => span_mask,
-        }?;
+            TENSOR_INPUT_IDS => Tensor::from_array(encoded.input_ids)?,
+            TENSOR_ATTENTION_MASK => Tensor::from_array(encoded.attention_masks)?,
+            TENSOR_WORD_MASK => Tensor::from_array(encoded.word_masks)?,
+            TENSOR_TEXT_LENGTHS => Tensor::from_array(encoded.text_lengths)?,
+            TENSOR_SPAN_IDX => Tensor::from_array(span_idx)?,
+            TENSOR_SPAN_MASK => Tensor::from_array(span_mask)?,
+        };
         Ok(Self {
             tensors: inputs.into(),
             context: EntityContext { 
@@ -159,17 +160,17 @@ mod tests {
         let encoded = EncodedInput::from(prepared, &tokenizer)?;
         let spans = SpanTensors::from(encoded, 12)?;
         let span_idx = get_tensor("span_idx", &spans.tensors)?;
-        let span_idx = span_idx.try_extract_tensor::<i64>()?;        
+        let span_idx = span_idx.try_extract_array::<i64>()?;
         let span_masks = get_tensor("span_mask", &spans.tensors)?;
-        let span_masks = span_masks.try_extract_tensor::<bool>()?;        
+        let span_masks = span_masks.try_extract_array::<bool>()?;
         // Some prints
         if false {
             println!("Spans: {:?}", &span_idx);
             println!("Spans Masks: {:?}", &span_masks);
         }
         // Assertions (TODO: add more)
-        assert_eq!(span_idx.shape(), vec![2, 84, 2]);
-        assert_eq!(span_masks.shape(), vec![2, 84]);
+        assert_eq!(span_idx.shape(), &[2, 84, 2]);
+        assert_eq!(span_masks.shape(), &[2, 84]);
         // Everything rules
         Ok(())
     }

--- a/src/model/input/tensors/token.rs
+++ b/src/model/input/tensors/token.rs
@@ -1,4 +1,5 @@
 use ort::session::SessionInputs;
+use ort::value::Tensor;
 use composable::Composable;
 use crate::util::result::Result;
 use super::super::encoded::EncodedInput;
@@ -21,11 +22,11 @@ impl TokenTensors<'_> {
 
     pub fn from(encoded: EncodedInput) -> Result<Self> {
         let inputs = ort::inputs!{
-            TENSOR_INPUT_IDS => encoded.input_ids,
-            TENSOR_ATTENTION_MASK => encoded.attention_masks,
-            TENSOR_WORD_MASK => encoded.word_masks,
-            TENSOR_TEXT_LENGTHS => encoded.text_lengths,
-        }?;
+            TENSOR_INPUT_IDS => Tensor::from_array(encoded.input_ids)?,
+            TENSOR_ATTENTION_MASK => Tensor::from_array(encoded.attention_masks)?,
+            TENSOR_WORD_MASK => Tensor::from_array(encoded.word_masks)?,
+            TENSOR_TEXT_LENGTHS => Tensor::from_array(encoded.text_lengths)?,
+        };
         Ok(Self {
             tensors: inputs.into(),
             context: EntityContext { 

--- a/src/model/output/decoded/span.rs
+++ b/src/model/output/decoded/span.rs
@@ -41,10 +41,10 @@ impl TensorsToDecoded {
 
         // look for logits and check its shape
         let logits = input.tensors.get(TENSOR_LOGITS).ok_or("logits not found in model output")?;
-        self.check_shape(logits.shape()?, &input.context)?;
+        self.check_shape(logits.shape(), &input.context)?;
         
         // extract the actual array
-        let array = logits.try_extract_tensor::<f32>()?;
+        let array = logits.try_extract_array::<f32>()?;
 
         // iterate over the sequences
         for sequence_id in 0..batch_size {
@@ -81,9 +81,9 @@ impl TensorsToDecoded {
 
     /// Checks coherence of the output shape
     /// Expected shape is (batch_size, num_words, num_spans, num_classes)
-    fn check_shape(&self, actual_shape: Vec<i64>, context: &EntityContext) -> Result<()> {
+    fn check_shape(&self, actual_shape: &[i64], context: &EntityContext) -> Result<()> {
         let expected_shape = vec![context.texts.len() as i64, context.num_words as i64, self.max_width as i64, context.entities.len() as i64];
-        if actual_shape != expected_shape {
+        if actual_shape != expected_shape.as_slice() {
             Err("unexpected logits shape".into())
         }
         else {

--- a/src/model/output/decoded/token.rs
+++ b/src/model/output/decoded/token.rs
@@ -45,10 +45,10 @@ impl TensorsToDecoded {
 
         // look for logits and check its shape
         let logits = input.tensors.get(TENSOR_LOGITS).ok_or("logits not found in model output")?;
-        self.check_shape(logits.shape()?, &input.context)?;
+        self.check_shape(logits.shape(), &input.context)?;
     
         // extract the actual array
-        let array  = logits.try_extract_tensor::<f32>()?;
+        let array  = logits.try_extract_array::<f32>()?;
         //println!("{:?}", array.map(|x| crate::util::math::sigmoid(*x)));
 
         // iterate over sequences
@@ -136,9 +136,9 @@ impl TensorsToDecoded {
     /// Checks coherence of the output shape.
     /// Expected shape is (3, batch_size, num_words, num_classes).
     /// The first dimension is related to `start`, `end` and `inside` positions in that order.
-    fn check_shape(&self, actual_shape: Vec<i64>, context: &EntityContext) -> Result<()> {
+    fn check_shape(&self, actual_shape: &[i64], context: &EntityContext) -> Result<()> {
         let expected_shape = vec![3, context.texts.len() as i64, context.num_words as i64, context.entities.len() as i64];
-        if actual_shape != expected_shape {
+        if actual_shape != expected_shape.as_slice() {
             Err("unexpected logits shape".into())
         }
         else {

--- a/src/model/output/decoded/token_flat.rs
+++ b/src/model/output/decoded/token_flat.rs
@@ -112,7 +112,7 @@ impl TensorsToDecoded {
 impl Composable<TensorOutput<'_>, SpanOutput> for TensorsToDecoded {
     fn apply(&self, input: TensorOutput) -> Result<SpanOutput> {        
         let logits = input.tensors.get("logits").ok_or("logits not found in model output")?;
-        let (_shape, logits) = logits.try_extract_raw_tensor::<f32>()?;
+        let (_shape, logits) = logits.try_extract_tensor::<f32>()?;
         let spans = self.decoder.decode(logits, &input.context)?;        
         Ok(SpanOutput::new(input.context.texts, input.context.entities, spans))      
     }

--- a/src/model/output/tensors.rs
+++ b/src/model/output/tensors.rs
@@ -8,12 +8,12 @@ use crate::model::pipeline::context::EntityContext;
 /// Represents the raw tensor output of the inference step
 pub struct TensorOutput<'a> {
     pub context: EntityContext,
-    pub tensors: SessionOutputs<'a, 'a>,
+    pub tensors: SessionOutputs<'a>,
 }
 
 
 impl<'a> TensorOutput<'a> {
-    pub fn from(tensors: SessionOutputs<'a, 'a>, context: EntityContext) -> Self {
+    pub fn from(tensors: SessionOutputs<'a>, context: EntityContext) -> Self {
         Self { 
             context,
             tensors 
@@ -27,8 +27,8 @@ impl<'a> TensorOutput<'a> {
 pub struct SessionOutputToTensors { }
 
 
-impl<'a> Composable<(SessionOutputs<'a, 'a>, EntityContext), TensorOutput<'a>> for SessionOutputToTensors {
-    fn apply(&self, input: (SessionOutputs<'a, 'a>, EntityContext)) -> Result<TensorOutput<'a>> {
+impl<'a> Composable<(SessionOutputs<'a>, EntityContext), TensorOutput<'a>> for SessionOutputToTensors {
+    fn apply(&self, input: (SessionOutputs<'a>, EntityContext)) -> Result<TensorOutput<'a>> {
         Ok(TensorOutput::from(input.0, input.1))
     }
 }


### PR DESCRIPTION
Hi! This ports gline-rs to `ort 2.0.0-rc.12` / `ndarray 0.17`. Companion PR: fbilhaut/orp#3 (this PR temporarily points the `orp` git dependency at that branch so it builds standalone — happy to flip it back to `fbilhaut/orp` or a released version once that lands).

## Why

`ort 2.0.0-rc.9` targets ONNX Runtime 1.20.x; current system installs ship 1.24+ (Homebrew: 1.26). rc.12 supports ORT 1.17–1.24 via multiversioning and empirically works against 1.26 with `load-dynamic` — all 17 unit tests here pass against ONNX Runtime 1.26.

## What changed (mechanical, driven by rc.9 → rc.12 API changes)

- `ort::inputs!` no longer converts ndarray arrays implicitly (and no longer returns `Result`): input tensors are now wrapped explicitly with `Tensor::from_array(...)?` in the token/span tensor builders.
- `SessionOutputs` lost its second lifetime parameter.
- `try_extract_tensor::<T>()` → `try_extract_array::<T>()` for ndarray views; `try_extract_raw_tensor` → `try_extract_tensor` for the `(&Shape, &[T])` form (token_flat decoder).
- `Value::shape()` returns `&Shape` directly (derefs to `[i64]`); `check_shape` takes `&[i64]` accordingly.

One operational note that may be worth a README line: with rc.12 + `load-dynamic`, a missing/unresolvable ONNX Runtime dylib makes the first ort call block indefinitely rather than return an error — setting `ORT_DYLIB_PATH` explicitly avoids confusing hangs in tests.

Thanks for gline-rs — we use it in production (Apache-2.0 anvil, NER via GLiNER) and would love to get back onto plain crates.io releases.